### PR TITLE
fix: NameError: name 'frappe' is not defined

### DIFF
--- a/erpnext/patches/v12_0/set_ip_record_field_in_si.py
+++ b/erpnext/patches/v12_0/set_ip_record_field_in_si.py
@@ -1,3 +1,4 @@
+import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from erpnext.domains.healthcare import data
 


### PR DESCRIPTION
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v12_0/set_ip_record_field_in_si.py", line 5, in execute
    if "Healthcare" not in frappe.get_active_domains():
NameError: name 'frappe' is not defined

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

